### PR TITLE
Fix magnet link info hash extraction

### DIFF
--- a/btfs-hook.lua
+++ b/btfs-hook.lua
@@ -130,7 +130,7 @@ end
 
 -- gets the info hash or torrent filename for use as the mount directory name
 local parse_url = function (url)
-	return url:match('^magnet:%?xt=urn:btih:*.')
+	return url:match('^magnet:.*[?&]xt=urn:bt[im]h:([a-zA-Z0-9]*)&?')
 	    or url:gsub('[?#].*', '', 1):match('/([^/]+%.torrent)$')
 end
 


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Magnet_URI_scheme

https://gitspartv.github.io/lua-patterns/?pattern=%5Emagnet%3A.*%5B%3F%26%5Dxt%3Durn%3Abt%5Bim%5Dh%3A(%5Ba-zA-Z0-9%5D*)%26%3F